### PR TITLE
Add --version flag

### DIFF
--- a/cmd/kubepug.go
+++ b/cmd/kubepug.go
@@ -22,6 +22,9 @@ var (
 	kubernetesConfigFlags *genericclioptions.ConfigFlags
 )
 
+// The version var will be used to generate the --version command and is passed by goreleaser
+var version string
+
 var (
 	k8sVersion        string
 	forceDownload     bool
@@ -41,8 +44,16 @@ var (
 		Example:      filepath.Base(os.Args[0]),
 		Args:         cobra.MinimumNArgs(0),
 		RunE:         runPug,
+		Version:      getVersion(),
 	}
 )
+
+func getVersion() string {
+	if version == "" {
+		return "master branch"
+	}
+	return version
+}
 
 func runPug(cmd *cobra.Command, args []string) error {
 	config := lib.Config{


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

Fixes: #71 

This adds the --version flag based in what goreleaser passes to the build.

This can be tested with  ``go build -o output/kubepug -ldflags "-X main.version=teste123"  cmd/kubepug.go``