### PR TITLE
feat: Add arm build for M1 MacBooks to .krew.yaml

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -25,7 +25,13 @@ spec:
         os: darwin
         arch: amd64
     {{addURIAndSha "https://github.com/rikatz/kubepug/releases/download/{{ .TagName }}/kubepug_darwin_amd64.tar.gz" .TagName }}
-    bin: "kubepug" 
+    bin: "kubepug"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/rikatz/kubepug/releases/download/{{ .TagName }}/kubepug_darwin_arm64.tar.gz" .TagName }}
+    bin: "kubepug"
   - selector:
       matchLabels:
         os: linux


### PR DESCRIPTION
This PR adds the arm64 build for Mac to the manifest, so that in the future this plugin can be installed via krew.

Related: #191