### PR TITLE
Enable snap builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Deprecations  AKA KubePug - Pre UpGrade (Checker)
 [![Build Status](https://github.com/rikatz/kubepug/actions/workflows/build.yml/badge.svg)](https://github.com/rikatz/kubepug/actions/workflows/build.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rikatz/kubepug)](https://goreportcard.com/report/github.com/rikatz/kubepug)
+[![kubepug](https://snapcraft.io/kubepug/badge.svg)](https://snapcraft.io/kubepug)
 
 
 ![Kubepug](assets/kubepug.png)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,36 @@
+name: kubepug
+base: core20
+summary: CLI to verify Kubernetes manifests and clusters on deprecated APIs
+description: |
+  Kubepug is a CLI and kubectl plugin, that can verify if a Kubernetes cluster or Kubernetes manifests contains deprecated and deleted APIs.
+  It can check against a specific Kubernetes version, and depending on the API propose a replacement API
+grade: stable
+confinement: strict
+adopt-info: kubepug
+
+apps:
+  kubepug:
+    command: bin/kubepug
+    plugs:
+      - home
+      - network
+parts:
+  kubepug:
+    plugin: go
+    source-type: git
+    source: https://github.com/rikatz/kubepug
+    override-pull: |
+      snapcraftctl pull
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info wethr | awk '$1 == "latest/beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
+    build-packages:
+      - git
+      - sed


### PR DESCRIPTION
Fixes #293 

This PR enables snapbuilds on Kubepug.

I have already reserved the name `kubepug` and as soon as I can get a machine logging to snap (my build machine is not), I will publish the beta version on beta channel, and enable the automatic build on snap dashboards