### PR TITLE
Add message on new db

### DIFF
--- a/pkg/formatter/stdout.go
+++ b/pkg/formatter/stdout.go
@@ -10,6 +10,10 @@ import (
 	"github.com/rikatz/kubepug/pkg/results"
 )
 
+const (
+	footer = "Kubepug validates the APIs using Kubernetes markers. To know what are the deprecated and deleted APIS it checks, please go to https://kubepug.xyz/status/"
+)
+
 type stdout struct {
 	plain bool
 }
@@ -79,6 +83,12 @@ func (f *stdout) Output(data results.Result) ([]byte, error) {
 			s = fmt.Sprintf("%s%s\n", s, items)
 		}
 	}
+
+	if len(data.DeletedAPIs) == 0 && len(data.DeprecatedAPIs) == 0 {
+		s = "\nNo deprecated or deleted APIs found"
+	}
+
+	s = fmt.Sprintf("%s\n\n%s", s, footer)
 
 	if f.plain {
 		s = strings.ReplaceAll(s, "\t", "")

--- a/pkg/results/types.go
+++ b/pkg/results/types.go
@@ -28,6 +28,6 @@ type ResultItem struct {
 
 // Result to show final user
 type Result struct {
-	DeprecatedAPIs []ResultItem `json:"deprecated_apis,omitempty" yaml:"deprecated_apis,omitempty"`
-	DeletedAPIs    []ResultItem `json:"deleted_apis,omitempty" yaml:"deleted_apis,omitempty"`
+	DeprecatedAPIs []ResultItem `json:"deprecated_apis" yaml:"deprecated_apis"`
+	DeletedAPIs    []ResultItem `json:"deleted_apis" yaml:"deleted_apis"`
 }


### PR DESCRIPTION
Previously kubepug exited without any message in case of no deprecated or deleted API found. 

This change turns it a bit more friendly, letting the user know it has executed and no problem was found

Fixes: #427 